### PR TITLE
Close any open 'compare' panels after buttons have been clicked

### DIFF
--- a/public_html/js/index.js
+++ b/public_html/js/index.js
@@ -26,6 +26,7 @@
 			// perform review action then cleanup
 			reviewFn( id, status, function () {
 				document.activeElement.blur(); // remove focus from button
+				$( this ).parents( 'article.record' ).find( '.compare-pane' ).slideUp(); // Close compare areas.
 				$( this ).removeClass( 'loading' );
 			}.bind( this ) );
 		} );


### PR DESCRIPTION
This collapses the current record's two compare panels if either
of them is still open when the user clicks 'page fixed' or 'no
action needed'.

Bug: https://phabricator.wikimedia.org/T141820