### PR TITLE
Redirect to the root URL on logout

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -278,7 +278,7 @@ class App extends AbstractApp {
 					} )->name( 'home' )->setConditions( $routeConditions );
 				$slim->get( 'logout', function () use ( $slim ) {
 					$slim->authManager->logout();
-					$slim->redirect( $slim->urlFor( 'home' ) );
+					$slim->redirect( $slim->urlFor( 'root' ) );
 				} )->name( 'logout' );
 				$slim->get( ':wikiLang/loadmore', function ( $wikiLang ) use ( $slim ) {
 					$page = new Controllers\CopyPatrol( $slim );


### PR DESCRIPTION
It was redirecting to the 'home' URL, which requires the language
parameter.

Bug: https://phabricator.wikimedia.org/T150919