### PR TITLE
Fix Leaderboard language-specific links

### DIFF
--- a/public_html/templates/leaderboard.html
+++ b/public_html/templates/leaderboard.html
@@ -2,14 +2,13 @@
 {% import _self as macros %}
 
 {# must pass in wiki and username as view-level variables are not accessible in macros #}
-{% macro leaderboard_list( wiki, dataset, username ) %}
+{% macro leaderboard_list( wikiLang, dataset, username ) %}
 	<ol class="leaderboard-list">
 		{% for leader in dataset %}
 			<li class="ellipsis">
-				<a target="_blank" href="{{ wiki }}/wiki/User:{{ leader['user'] }}"
-				   class="{{ username == leader['user'] ? 'mine' : '' }}">{{ leader['user'] }}</a>
-				:
-				{{ leader['count'] | number_format }}</li>
+				<a target="_blank" href="https://{{ wikiLang }}.wikipedia.org/wiki/User:{{ leader.user }}"
+				   class="{{ username == leader.user ? 'mine' : '' }}">{{ leader.user }}</a>:
+				{{ leader.count | number_format }}</li>
 		{% endfor %}
 	</ol>
 {% endmacro %}
@@ -24,15 +23,15 @@
 		<div class="text-center clearfix">
 			<span class="leaderboard-column col-sm-4">
 				<h3>{{ 'lboard-week'|message|raw }}</h3>
-				{{ macros.leaderboard_list( wiki, data['last-week'], user.name ) }}
+				{{ macros.leaderboard_list( wikiLang, data['last-week'], user.name ) }}
 			</span>
 			<span class="leaderboard-column col-sm-4">
 				<h3>{{ 'lboard-month'|message|raw }}</h3>
-				{{ macros.leaderboard_list( wiki, data['last-month'], user.name ) }}
+				{{ macros.leaderboard_list( wikiLang, data['last-month'], user.name ) }}
 			</span>
 			<span class="leaderboard-column col-sm-4">
 				<h3>{{ 'lboard-alltime'|message|raw }}</h3>
-				{{ macros.leaderboard_list( wiki, data['all-time'], user.name ) }}
+				{{ macros.leaderboard_list( wikiLang, data['all-time'], user.name ) }}
 			</span>
 		</div>
 	</section>

--- a/src/App.php
+++ b/src/App.php
@@ -330,7 +330,7 @@ class App extends AbstractApp {
 			function ( $wikiLang ) use ( $slim ) {
 				$leaderboard = new Leaderboard( $slim );
 				$leaderboard->setDao( $this->getPlagiabotDao() );
-				$this->getWikiDao( $wikiLang );
+				$leaderboard->setWikiDao( $this->getWikiDao( $wikiLang ) );
 				$leaderboard();
 			} )->name( 'leaderboard' )->setConditions( $routeConditions );
 	}

--- a/src/Controllers/Leaderboard.php
+++ b/src/Controllers/Leaderboard.php
@@ -21,24 +21,7 @@
  */
 namespace Plagiabot\Web\Controllers;
 
-use Plagiabot\Web\Dao\PlagiabotDao;
-use Slim\Slim;
-use Wikimedia\Slimapp\Controller;
-
-class Leaderboard extends Controller {
-
-	/**
-	 * @var PlagiabotDao
-	 */
-	protected $dao;
-
-	/**
-	 * @param Slim $slim Slim application
-	 */
-	public function __construct( Slim $slim = null, $lang = 'en' ) {
-		parent::__construct( $slim );
-		$this->lang = $lang;
-	}
+class Leaderboard extends CopyPatrol {
 
 	/**
 	 * Handle GET route for app


### PR DESCRIPTION
This updates the Leaderboard controller to follow the same pattern
as the other controllers and inherit from CopyPatrol. This makes
it simpler to retrieve the current wiki langugage in the same way
that it's done elsewhere (and so is hopefully less confusing).

Some of the Twig variable usages were also simplified to the dot
syntax rather than the array syntax.

Bug: https://phabricator.wikimedia.org/T150928