### PR TITLE
Add a dropdown for switching between Wikipedias

### DIFF
--- a/public_html/templates/header.html
+++ b/public_html/templates/header.html
@@ -1,16 +1,57 @@
 <header class="app-header">
-	<a href="{{ urlFor( 'home', {wikiLang:wikiLang} ) }}"><img src="{{ siteUrl( 'images/copypatrol.png' ) }}"/></a>
-	<a class="header-link" target="_blank" href="https://meta.wikimedia.org/wiki/CopyPatrol">{{ 'documentation' | message }}</a>
-	<a class="header-link" target="_blank" href="https://meta.wikimedia.org/wiki/Talk:CopyPatrol">{{ 'feedback' | message | raw }}</a>
-	<a class="header-link" href="{{ urlFor( 'leaderboard', {wikiLang:wikiLang} ) }}">{{ 'leaderboard' | message }}</a>
-	{% if user %}
-		<a href="{{ urlFor( 'logout' ) }}" id="login-btn" class="btn btn-sm btn-default {{ user ? 'logged-in' : '' }}">
-			<span class=" glyphicon glyphicon-log-in"></span> {{ 'logout' | message }}<br>
-			<small>{{ 'header-loggedin' | message( user.name ) }}</small>
-		</a>
-	{% else %}
-		<a href="{{ urlFor( 'oauth_init' ) }}" id="login-btn" class="btn btn-sm btn-default">
-			<span class=" glyphicon glyphicon-log-in"></span> {{ 'login' | message }}
-		</a>
-	{% endif %}
+	<nav class="navbar navbar-default">
+		<div class="container-fluid">
+			<div class="navbar-header">
+				<button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#main-navigation" aria-expanded="false">
+					<span class="sr-only">Toggle navigation</span>
+					<span class="icon-bar"></span>
+					<span class="icon-bar"></span>
+					<span class="icon-bar"></span>
+				</button>
+				<a class="navbar-brand" href="{{ urlFor( 'home', {wikiLang:wikiLang} ) }}">
+					<img src="{{ siteUrl( 'images/copypatrol.png' ) }}" alt="'CopyPatrol' logo (with text)" />
+				</a>
+			</div>
+
+			<!-- Collect the nav links, forms, and other content for toggling -->
+			<div class="collapse navbar-collapse" id="main-navigation">
+				<ul class="nav navbar-nav navbar-left">
+					<li class="dropdown">
+						<a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+							{{ (wikiLang~'-wikipedia') | message }} <span class="caret"></span>
+						</a>
+						<ul class="dropdown-menu">
+							{% if wikiLang != 'en' %}
+							<li><a href="{{ urlFor( currentRoute, {wikiLang:'en'} ) }}">{{ ('en-wikipedia') | message }}</a></li>
+							{% endif %}
+							{% if wikiLang != 'fr' %}
+							<li><a href="{{ urlFor( currentRoute, {wikiLang:'fr'} ) }}">{{ ('fr-wikipedia') | message }}</a></li>
+							{% endif %}
+						</ul>
+					</li>
+					<li><a target="_blank" href="https://meta.wikimedia.org/wiki/CopyPatrol">{{ 'documentation' | message }}</a></li>
+					<li><a target="_blank" href="https://meta.wikimedia.org/wiki/Talk:CopyPatrol">{{ 'feedback' | message }}</a></li>
+					<li><a href="{{ urlFor( 'leaderboard', {wikiLang:wikiLang} ) }}">{{ 'leaderboard' | message }}</a></li>
+				</ul>
+
+				{% if user %}
+				<form class="navbar-form navbar-right" method="get" action="{{ urlFor( 'logout' ) }}">
+					<div class="form-group">
+						<label>{{ 'header-loggedin' | message( user.name ) }}</label>
+						<button class="btn btn-default logged-in form-control" id="logout-btn">
+							<span class="glyphicon glyphicon-log-out"></span> {{ 'logout' | message }}
+						</button>
+					</div>
+				</form>
+				{% else %}
+				<form class="navbar-form navbar-right" method="get" action="{{ urlFor( 'oauth_init' ) }}">
+					<button class="btn btn-default" id="login-btn">
+						<span class="glyphicon glyphicon-log-in"></span> {{ 'login' | message }}
+					</button>
+				</form>
+				{% endif %}
+
+			</div><!-- /.navbar-collapse -->
+		</div><!-- /.container-fluid -->
+	</nav>
 </header>

--- a/src/App.php
+++ b/src/App.php
@@ -243,6 +243,8 @@ class App extends AbstractApp {
 				// determine if we are on the staging environment, so we can show a banner in the view
 				$rootUri = $slim->request->getRootUri();
 				$slim->view->set( 'staging', strpos( $rootUri, 'plagiabot' ) );
+				// Give the view the current route name, for inter-language linking.
+				$slim->view->set( 'currentRoute', $slim->router->getCurrentRoute()->getName() );
 			},
 			'require-auth' => function () use ( $slim ) {
 				if ( !$slim->authManager->isAuthenticated() ) {
@@ -276,6 +278,13 @@ class App extends AbstractApp {
 						$page->setWikiDao( $this->getWikiDao( $wikiLang ) );
 						$page();
 					} )->name( 'home' )->setConditions( $routeConditions );
+				$slim->get( ':wikiLang/leaderboard',
+					function ( $wikiLang ) use ( $slim ) {
+						$leaderboard = new Leaderboard( $slim );
+						$leaderboard->setDao( $this->getPlagiabotDao() );
+						$leaderboard->setWikiDao( $this->getWikiDao( $wikiLang ) );
+						$leaderboard();
+					} )->name( 'leaderboard' )->setConditions( $routeConditions );
 				$slim->get( 'logout', function () use ( $slim ) {
 					$slim->authManager->logout();
 					$slim->redirect( $slim->urlFor( 'root' ) );
@@ -328,13 +337,6 @@ class App extends AbstractApp {
 					$page( 'callback' );
 				} )->name( 'oauth_callback' );
 			} );
-		$slim->get( '/:wikiLang/leaderboard', $middleware['inject-user'],
-			function ( $wikiLang ) use ( $slim ) {
-				$leaderboard = new Leaderboard( $slim );
-				$leaderboard->setDao( $this->getPlagiabotDao() );
-				$leaderboard->setWikiDao( $this->getWikiDao( $wikiLang ) );
-				$leaderboard();
-			} )->name( 'leaderboard' )->setConditions( $routeConditions );
 	}
 
 	/**

--- a/src/Less/index.less
+++ b/src/Less/index.less
@@ -272,31 +272,17 @@ body {
 	padding: 12px 12px 95px;
 }
 
-#login-btn {
-	height: 48px;
-	line-height: 36px;
-	padding: 5px 20px;
-	position: absolute;
-	right: 14px;
-	top: 14px;
-
-	&.logged-in {
-		line-height: inherit;
-	}
-}
-
-.app-header {
+.app-header .navbar {
 	background: url('images/gradient.png');
 	border-bottom: solid 2px #ccc;
 	margin-bottom: 10px;
-	padding: 15px;
 	text-align: left;
 }
-
-.header-link {
-	font-size: 18px;
-	margin-left: 20px;
-	vertical-align: -7px;
+.app-header .navbar-brand { padding:2px }
+.app-header .navbar-left { font-size:larger }
+.app-header .navbar-right label {
+	font-weight:normal;
+	margin: 5px 20px 0 0;
 }
 
 // absolutely positioned at the bottom to appear at the bottom


### PR DESCRIPTION
This changes to using the Bootstrap navbar for the main menu, so
that it's easier to incorporate a dropdown with which to switch
from English to French or vice versa. This switch will to to the
corresponding other-language page (so if you're on the leaderboard
and switch you'll be on the other language's leaderboard).

Bug: https://phabricator.wikimedia.org/T150956