### PR TITLE
Only show the WikiProject search field when required

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -165,16 +165,16 @@
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579"
+                "reference": "2693c101803ca78b27972d84081d027fca790a1e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/c10d860e2a9595f8883527fa0021c7da9e65f579",
-                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/2693c101803ca78b27972d84081d027fca790a1e",
+                "reference": "2693c101803ca78b27972d84081d027fca790a1e",
                 "shasum": ""
             },
             "require": {
@@ -212,7 +212,7 @@
             "keywords": [
                 "promise"
             ],
-            "time": "2016-05-18 16:56:05"
+            "time": "2016-11-18 17:47:58"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -324,16 +324,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "1.21.0",
+            "version": "1.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "f42fbdfd53e306bda545845e4dbfd3e72edb4952"
+                "reference": "bad29cb8d18ab0315e6c477751418a82c850d558"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/f42fbdfd53e306bda545845e4dbfd3e72edb4952",
-                "reference": "f42fbdfd53e306bda545845e4dbfd3e72edb4952",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/bad29cb8d18ab0315e6c477751418a82c850d558",
+                "reference": "bad29cb8d18ab0315e6c477751418a82c850d558",
                 "shasum": ""
             },
             "require": {
@@ -344,7 +344,7 @@
                 "psr/log-implementation": "1.0.0"
             },
             "require-dev": {
-                "aws/aws-sdk-php": "^2.4.9",
+                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
                 "doctrine/couchdb": "~1.0@dev",
                 "graylog2/gelf-php": "~1.0",
                 "jakub-onderka/php-parallel-lint": "0.9",
@@ -398,7 +398,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2016-07-29 03:23:52"
+            "time": "2016-11-26 00:15:39"
         },
         {
             "name": "oyejorge/less.php",
@@ -826,16 +826,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.27.0",
+            "version": "v1.28.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "3c6c0033fd3b5679c6e1cb60f4f9766c2b424d97"
+                "reference": "b22ce0eb070e41f7cba65d78fe216de29726459c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/3c6c0033fd3b5679c6e1cb60f4f9766c2b424d97",
-                "reference": "3c6c0033fd3b5679c6e1cb60f4f9766c2b424d97",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/b22ce0eb070e41f7cba65d78fe216de29726459c",
+                "reference": "b22ce0eb070e41f7cba65d78fe216de29726459c",
                 "shasum": ""
             },
             "require": {
@@ -843,12 +843,12 @@
             },
             "require-dev": {
                 "symfony/debug": "~2.7",
-                "symfony/phpunit-bridge": "~2.7"
+                "symfony/phpunit-bridge": "~3.2@dev"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.27-dev"
+                    "dev-master": "1.28-dev"
                 }
             },
             "autoload": {
@@ -883,7 +883,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2016-10-25 19:17:17"
+            "time": "2016-11-23 18:41:40"
         },
         {
             "name": "wikimedia/simplei18n",
@@ -944,12 +944,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wikimedia/wikimedia-slimapp.git",
-                "reference": "35745b79e8567b5a8750ad6be6c10c2046368a21"
+                "reference": "c66a25d6e06087637da24c27c6beb30c3e736a02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wikimedia/wikimedia-slimapp/zipball/35745b79e8567b5a8750ad6be6c10c2046368a21",
-                "reference": "35745b79e8567b5a8750ad6be6c10c2046368a21",
+                "url": "https://api.github.com/repos/wikimedia/wikimedia-slimapp/zipball/c66a25d6e06087637da24c27c6beb30c3e736a02",
+                "reference": "c66a25d6e06087637da24c27c6beb30c3e736a02",
                 "shasum": ""
             },
             "require": {
@@ -989,7 +989,7 @@
             ],
             "description": "Common classes to help with creating an application using the Slim micro framework and Twig template engine.",
             "homepage": "https://github.com/wikimedia/wikimedia-slimapp",
-            "time": "2016-08-30 23:13:05"
+            "time": "2016-11-23 18:29:30"
         }
     ],
     "packages-dev": [
@@ -1231,16 +1231,16 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.2",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443"
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/b39c7a5b194f9ed7bd0dd345c751007a41862443",
-                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
                 "shasum": ""
             },
             "require": {
@@ -1274,20 +1274,20 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-06-10 07:14:17"
+            "time": "2016-11-25 06:54:22"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.6.1",
+            "version": "v1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "58a8137754bc24b25740d4281399a4a3596058e0"
+                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/58a8137754bc24b25740d4281399a4a3596058e0",
-                "reference": "58a8137754bc24b25740d4281399a4a3596058e0",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/6c52c2722f8460122f96f86346600e1077ce22cb",
+                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb",
                 "shasum": ""
             },
             "require": {
@@ -1295,10 +1295,11 @@
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
                 "sebastian/comparator": "^1.1",
-                "sebastian/recursion-context": "^1.0"
+                "sebastian/recursion-context": "^1.0|^2.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.0"
+                "phpspec/phpspec": "^2.0",
+                "phpunit/phpunit": "^4.8 || ^5.6.5"
             },
             "type": "library",
             "extra": {
@@ -1336,7 +1337,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-06-07 08:13:47"
+            "time": "2016-11-21 14:58:47"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1402,16 +1403,16 @@
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
                 "shasum": ""
             },
             "require": {
@@ -1445,7 +1446,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2016-10-03 07:40:28"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1583,16 +1584,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.28",
+            "version": "4.8.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "558a3a0d28b4cb7e4a593a4fbd2220e787076225"
+                "reference": "a534e04d0bd39c557c2881c341efd06fa6f1292a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/558a3a0d28b4cb7e4a593a4fbd2220e787076225",
-                "reference": "558a3a0d28b4cb7e4a593a4fbd2220e787076225",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a534e04d0bd39c557c2881c341efd06fa6f1292a",
+                "reference": "a534e04d0bd39c557c2881c341efd06fa6f1292a",
                 "shasum": ""
             },
             "require": {
@@ -1608,7 +1609,7 @@
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "^1.0.6",
                 "phpunit/phpunit-mock-objects": "~2.3",
-                "sebastian/comparator": "~1.1",
+                "sebastian/comparator": "~1.2.2",
                 "sebastian/diff": "~1.2",
                 "sebastian/environment": "~1.3",
                 "sebastian/exporter": "~1.2",
@@ -1651,7 +1652,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-11-14 06:25:28"
+            "time": "2016-12-01 17:05:48"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1711,22 +1712,22 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.0",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
+                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
                 "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "sebastian/exporter": "~1.2 || ~2.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.4"
@@ -1771,7 +1772,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26 15:48:44"
+            "time": "2016-11-19 09:18:40"
         },
         {
             "name": "sebastian/diff",
@@ -2161,25 +2162,31 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.1.6",
+            "version": "v3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "7ff51b06c6c3d5cc6686df69004a42c69df09e27"
+                "reference": "f2300ba8fbb002c028710b92e1906e7457410693"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/7ff51b06c6c3d5cc6686df69004a42c69df09e27",
-                "reference": "7ff51b06c6c3d5cc6686df69004a42c69df09e27",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/f2300ba8fbb002c028710b92e1906e7457410693",
+                "reference": "f2300ba8fbb002c028710b92e1906e7457410693",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.9"
             },
+            "require-dev": {
+                "symfony/console": "~2.8|~3.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -2206,24 +2213,24 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-24 18:41:13"
+            "time": "2016-11-18 21:17:59"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308"
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bb2d123231c095735130cc8f6d31385a44c7b308",
-                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3|^7.0"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.6",
@@ -2232,7 +2239,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -2256,7 +2263,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-08-09 15:02:57"
+            "time": "2016-11-23 20:04:58"
         }
     ],
     "aliases": [],

--- a/public_html/templates/base.html
+++ b/public_html/templates/base.html
@@ -101,6 +101,9 @@
 							</label>
 						</span>
 						{% endif %}
+
+					{% if hasWikiprojects %}
+					{# End the row and start a new one to display the WikiProjects' search box. #}
 					</div>
 					<div class="wikiproject-filter col-sm-12">
 						<label class="wikiproject-label" for="wikiproject-selector">
@@ -113,8 +116,11 @@
 						</select>
 						{# use hidden input field so we can submit with format 'WP1|WP2|WP3' #}
 						<input type="hidden" name="wikiprojects" value="{{ wikiprojects }}" formenctype="text/plain"/>
-						<button type="submit"
-						        class="btn btn-primary btn-sm btn-submit-filters">{{ 'submit' | message }}</button>
+					{% endif %}
+
+						<button type="submit" class="btn btn-primary btn-sm btn-submit-filters">
+							{{ 'submit' | message }}
+						</button>
 					</div>
 				</fieldset>
 			</form>
@@ -123,11 +129,13 @@
 		<section class="records">
 			{% block rowheader %}
 				<header class="header-div container-fluid">
-					<div class="header-col col-sm-3 text-center">{{ 'page' | message }}</div>
+					<div class="header-col {% if hasWikiprojects %}col-sm-3{% else %}col-sm-4{% endif %} text-center">{{ 'page' | message }}</div>
 					<div class="header-col col-sm-2 text-center">{{ 'diff' | message }}</div>
-					<div class="header-col col-sm-2 text-center">{{ 'editor' | message }}</div>
+					<div class="header-col {% if hasWikiprojects %}col-sm-2{% else %}col-sm-3{% endif %} text-center">{{ 'editor' | message }}</div>
+					{% if hasWikiprojects %}
 					<div class="header-col col-sm-3 text-center">{{ 'wikiprojects' | message }}</div>
-					<div class="header-col col-sm-2 text-center">{{ 'review' | message }}</div>
+					{% endif %}
+					<div class="header-col {% if hasWikiprojects %}col-sm-2{% else %}col-sm-3{% endif %} text-center">{{ 'review' | message }}</div>
 				</header>
 			{% endblock %}
 			<section class="record-container">

--- a/public_html/templates/index.html
+++ b/public_html/templates/index.html
@@ -20,7 +20,7 @@
 					data-status="{{ row.status }}">
 				<div class="row-container clearfix">
 					{# Div for page title #}
-					<div class="row-div col-sm-3 page-div">
+					<div class="row-div {% if hasWikiprojects %}col-sm-3{% else %}col-sm-4{% endif %} page-div">
 						<strong>
 							<a href='{{ row.page_link }}' target="_blank"
 							   class="{{ row.page_dead ? 'text-danger' : '' }}">{{ row.page_title }}</a>
@@ -48,7 +48,7 @@
 						{% endif %}
 					</div>
 					{# Div for editor information #}
-					<div class="row-div col-sm-2 text-center report-div">
+					<div class="row-div {% if hasWikiprojects %}col-sm-2{% else %}col-sm-3{% endif %} text-center report-div">
 						{% if row.editor %}
 							<a href='{{ row.editor_page }}' class="{{ row.editor_page_dead ? 'text-danger' : '' }}"
 							   target="_blank">{{ row.editor }}</a>
@@ -72,6 +72,7 @@
 							</div>
 						{% endif %}
 					</div>
+					{% if hasWikiprojects %}{# Note the odd nesting of this if-else. #}
 					<div class="row-div col-sm-3 text-center wikiproject-div">
 						{% if row.wikiprojects is not empty %}
 							{% for wp in row.wikiprojects %}
@@ -79,7 +80,8 @@
 							{% endfor %}
 						{% endif %}
 					</div>
-					<div class="row-div col-sm-2 text-center status-div">
+					{% endif %}
+					<div class="row-div {% if hasWikiprojects %}col-sm-2{% else %}col-sm-3{% endif %} text-center status-div">
 						<button data-id="{{ row.ithenticate_id }}"
 						        data-status="fixed"
 						        class="btn btn-success btn-block btn-fixed js-save-state {{ user ? 'clickable' : '' }}"

--- a/src/Controllers/CopyPatrol.php
+++ b/src/Controllers/CopyPatrol.php
@@ -354,6 +354,8 @@ class CopyPatrol extends Controller {
 		$this->view->set( 'filter', $filter );
 		$this->view->set( 'drafts', $drafts );
 		$this->view->set( 'draftsExist', $this->dao->draftsExist( $this->wikiDao->getLang() ) );
+		$hasWikiprojects = count( $this->dao->getWikiProjects( $this->wikiDao->getLang() ) ) > 0;
+		$this->view->set( 'hasWikiprojects', $hasWikiprojects );
 		$this->view->set( 'wikiprojects', $wikiprojects );
 		$this->view->set( 'wikiprojectsArray', $wikiprojectsArray );
 		$this->view->set( 'filterTypes', $this->getFilterTypes() );

--- a/src/Dao/PlagiabotDao.php
+++ b/src/Dao/PlagiabotDao.php
@@ -161,21 +161,28 @@ class PlagiabotDao extends AbstractDao {
 	}
 
 	/**
-	 * Get the names of Wikiprojects that a particular Wikipedia page belongs to.
+	 * Get the names of WikiProjects that a particular Wikipedia page belongs to.
 	 * @param string $lang The language code.
-	 * @param string $title Page title.
-	 * @return string[] Alphabetical list of Wikiprojects
+	 * @param string $title Page title. If null, all projects of $lang will be returned.
+	 * @return string Alphabetical list of WikiProjects
 	 */
-	public function getWikiProjects( $lang, $title ) {
+	public function getWikiProjects( $lang, $title = null ) {
+		$whereTitle = '';
+		$params = [ 'lang' => $lang ];
+		if ( !is_null( $title ) ) {
+			$whereTitle = 'AND wp_page_title = :title';
+			$params['title'] = $title;
+		}
 		$query = self::concat(
 			'SELECT wp_project FROM wikiprojects',
-			'WHERE wp_page_title = :title AND wp_lang = :lang',
+			'WHERE  wp_lang = :lang',
+			$whereTitle,
 			'ORDER BY wp_project ASC'
 		);
 
 		// extract out the WikiProject names from the result set
 		$wikiprojects = array_column(
-			$this->fetchAll( $query, [ 'lang' => $lang, 'title' => $title ] ),
+			$this->fetchAll( $query, $params ),
 			'wp_project'
 		);
 

--- a/src/Dao/WikiDao.php
+++ b/src/Dao/WikiDao.php
@@ -252,8 +252,8 @@ class WikiDao extends AbstractDao {
 		$links = $this->apiQuery( [
 			'prop' => 'links',
 			'titles' => 'User:EranBot/Copyright/User_whitelist'
-		] )['query']['pages'][0]['links'];
-		if ( !$links ) {
+		] );
+		if ( !isset( $links['query']['pages'][0]['links'] ) ) {
 			return [];
 		}
 		// return array with just usernames as strings, without the 'User:' prefix
@@ -261,7 +261,7 @@ class WikiDao extends AbstractDao {
 			// Split on : and pick the second element to get the username
 			// This is because for other wikis 'User:' may be different, but there was always be a colon
 			return explode( ':', $link['title'] )[1];
-		}, $links );
+		}, $links['query']['pages'][0]['links'] );
 	}
 
 	/**


### PR DESCRIPTION
This change hides the WikiProject search field if there
are no WikiProjects in the database for the Wikipedia language
in use.

Half of T152173 is fixed as well, because it's easier to test
this new functionality against a language (pt) that doesn't
have WikiProjects.

Composer is also updated, just for fun.

Bug: https://phabricator.wikimedia.org/T152134
Bug: https://phabricator.wikimedia.org/T152173