### PR TITLE
Allow searching for a page with the exact title

### DIFF
--- a/src/Dao/PlagiabotDao.php
+++ b/src/Dao/PlagiabotDao.php
@@ -74,6 +74,10 @@ class PlagiabotDao extends AbstractDao {
 				$filters[] = "page_title LIKE CONCAT('%', :searchtext, '%')";
 				$preparedParams['searchtext'] = $searchText;
 			}
+			if ( $searchCriteria == 'page_exact' && $searchText ) {
+				$filters[] = "page_title = :searchtext";
+				$preparedParams['searchtext'] = $searchText;
+			}
 			// allow filtering by user and status
 			if ( $filterUser ) {
 				$filters[] = "status_user = '$filterUser'";


### PR DESCRIPTION
When searchCriteria == 'page_exact', only the records
for this exact page will be returned unlike 'page' that
does a SQL like '%text%' comparison.

This will be used by PageTriage to link to CopyPatrol
results for a specific page.

Bug: https://phabricator.wikimedia.org/T201075