### PR TITLE
Incorporate revision id search

### DIFF
--- a/src/Controllers/CopyPatrol.php
+++ b/src/Controllers/CopyPatrol.php
@@ -393,7 +393,8 @@ class CopyPatrol extends Controller {
 			'lastId' => $lastId > 0 ? $lastId : null,
 			'drafts' => $drafts,
 			'searchText' => str_replace( ' ', '_', $searchText ),
-			'searchCriteria' => $searchCriteria
+			'searchCriteria' => $searchCriteria,
+			'revision' => $this->request->get( 'revision' ) ?: null
 		];
 
 		// filter by current user if they are logged and the filter is 'mine'


### PR DESCRIPTION
This change allows one to pass in a `revision=:revId` parameter in the query
string. If present, we'll attempt to load results for that revision ID and will
merge them in with any other records found from the search.

Bug: T207345

