### PR TITLE
Remove trailing slash middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "license": "GPL-3.0-or-later",
   "require": {
     "php": "^7.2",
+    "ext-json": "*",
     "oyejorge/less.php": "~1.5",
     "mediawiki/oauthclient": "~1.0",
     "wikimedia/slimapp": "dev-master",

--- a/src/App.php
+++ b/src/App.php
@@ -281,17 +281,10 @@ class App extends AbstractApp {
 					$slim->stop();
 				}
 			},
-			'trailing-slash' => function () use ( $slim ) {
-				// Remove trailing slashes
-				if ( substr( $_SERVER['REQUEST_URI'], -1 ) === '/' ) {
-					$uri = rtrim( $_SERVER['REQUEST_URI'], '/' );
-					$slim->redirect( $uri );
-				}
-			},
 		];
 
 		// Root route.
-		$slim->get( '/', $middleware['trailing-slash'], $middleware['inject-user'],
+		$slim->get( '/', $middleware['inject-user'],
 			$middleware['set-environment'],
 			function () use ( $slim ) {
 				// See if we have a cookie indicating last version used
@@ -310,7 +303,7 @@ class App extends AbstractApp {
 		)->name( 'root' );
 
 		// Language-based routes.
-		$slim->group( '/:wikiLang', $middleware['trailing-slash'], $middleware['inject-user'],
+		$slim->group( '/:wikiLang', $middleware['inject-user'],
 			$middleware['set-environment'],
 			function () use ( $slim, $middleware ) {
 				$routeConditions = [
@@ -367,7 +360,7 @@ class App extends AbstractApp {
 			} );
 
 		// Stylesheet route.
-		$slim->get( '/index.css', $middleware['trailing-slash'],
+		$slim->get( '/index.css',
 			function () use ( $slim ) {
 				// Compile LESS if need be, otherwise serve cached asset
 				// Cached files get automatically deleted if they are over a week old
@@ -398,7 +391,7 @@ class App extends AbstractApp {
 				} )->name( 'oauth_callback' );
 			}
 		);
-		$slim->get( '/logout', $middleware['trailing-slash'], $middleware['inject-user'],
+		$slim->get( '/logout', $middleware['inject-user'],
 			$middleware['set-environment'],
 			function () use ( $slim ) {
 				$slim->authManager->logout();


### PR DESCRIPTION
Apparently this isn't needed anymore, and it's actually breaking the
'home' route from redirecting to the page with the language code (e.g.
if your browser is set to English, it should redirect to /en)

Also add ext-json requirement to composer.json