### PR TITLE
Migrate from Travis to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI/CD
+
+on:
+    push:
+    pull_request:
+
+env:
+    COMPOSER_DISABLE_XDEBUG_WARN: "1"
+
+jobs:
+    build:
+        name: Build
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v3
+                with:
+                    fetch-depth: 0
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: '7.2'
+                    extensions: json
+                    tools: composer
+            -   run: composer update
+            -   run: composer test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: php
-php:
-- '7.2'
-sudo: false
-env:
-  global:
-  - COMPOSER_DISABLE_XDEBUG_WARN=1
-install: composer install
-script: composer test

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # CopyPatrol
 This is a web interface for [Plagiabot's Copyright RC feed](https://en.wikipedia.org/wiki/User:EranBot/Copyright/rc).
 
-[![Build Status](https://travis-ci.org/wikimedia/CopyPatrol.svg?branch=master)](https://travis-ci.org/wikimedia/CopyPatrol)
-
 ## To install locally
 1. Clone the repository and run `composer install`.
 2. Edit the `.env` file that was created by composer.


### PR DESCRIPTION
Builds on `travis-ci.org` ended back in June 2021. This means Travis has not been providing builds for this repo since then. True enough, the last build on Travis seems to be from [two years ago](https://travis-ci.org/wikimedia/CopyPatrol). Switching to GitHub Actions has been the course of action for pywikibot, and GitHub Actions supports an unlimited amount of free minutes for public projects, so this is a switch to GitHub Actions to get continuous integration back up.

From https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions:
> GitHub Actions usage is free for standard GitHub-hosted runners in public repositories, and for self-hosted runners.

This commit introduces one dependency: [`shivammathur/setup-php`](https://github.com/shivammathur/setup-php), a GitHub Action which enables the use of older PHP versions on the latest Ubuntu GitHub Action runners. I've checked that action and it's actively maintained and supported, and is also widely used among other workflows running PHP (~79.1k repositories).

Example of a working run: [here](https://github.com/ChlodAlejandro/CopyPatrol/actions/runs/4208252772/jobs/7304065646).