### PR TITLE
Add Dockerfile, development docker-compose

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -7,7 +7,7 @@ OAUTH_CALLBACK       = 'oob'
 
 # Credentials for private EranBot database.
 DB_HOST            = 127.0.0.1
-DB_PORT            = 4711
+DB_PORT            = 4712
 DB_USER            =
 DB_PASS            =
 DB_NAME_COPYPATROL = s51306__copyright_p
@@ -15,7 +15,7 @@ DB_NAME_COPYPATROL = s51306__copyright_p
 # Credentials for replicas.
 # On Toolforge, DB_REPLICA_HOST should be '*.web.db.svc.eqiad.wmflabs'
 DB_REPLICA_HOST    = 127.0.0.1
-DB_REPLICA_PORT    = 4712
+DB_REPLICA_PORT    = 4711
 DB_REPLICA_USER    =
 DB_REPLICA_PASS    =
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
     build:
-        name: Build
+        name: Build and test
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v3
@@ -23,3 +23,73 @@ jobs:
                     tools: composer
             -   run: composer update
             -   run: composer test
+    build_image:
+        name: Build Docker image
+        runs-on: ubuntu-latest
+        needs: build
+        strategy:
+            matrix:
+                targets:
+                    - name: production
+                      tag: wikimedia/copypatrol
+                    - name: development
+                      tag: wikimedia/copypatrol-development
+        steps:
+            -   name: Checkout code
+                uses: actions/checkout@v2
+
+            -   name: Set up QEMU
+                uses: docker/setup-qemu-action@v1
+
+            -   name: Set up Docker Buildx
+                id: buildx
+                uses: docker/setup-buildx-action@v1
+
+            - name: Build image
+              id: docker_build
+              uses: docker/build-push-action@v2
+              with:
+                  context: .
+                  target: ${{ matrix.targets.name }}
+                  tags: ${{ matrix.targets.tag }}:latest
+                  outputs: type=docker,dest=/tmp/copypatrol-${{ matrix.targets.name }}.image.tar
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max
+
+            - name: Image digest
+              run: echo ${{ steps.docker_build.outputs.digest }}
+
+            - name: Upload Docker image to artifacts
+              uses: actions/upload-artifact@v2
+              with:
+                  name: image-${{ matrix.targets.name }}
+                  path: /tmp/copypatrol-${{ matrix.targets.name }}.image.tar
+    analysis:
+        name: Analyze Docker images
+        runs-on: ubuntu-latest
+        needs: build_image
+        strategy:
+            matrix:
+                targets:
+                    - name: production
+                      tag: wikimedia/copypatrol
+                    - name: development
+                      tag: wikimedia/copypatrol-development
+
+        steps:
+            - name: Download Docker image from artifacts
+              uses: actions/download-artifact@v2
+              with:
+                  name: image-${{ matrix.targets.name }}
+                  path: /tmp
+
+            - name: Load image
+              run: |
+                  docker load --input /tmp/copypatrol-${{ matrix.targets.name }}.image.tar
+                  docker image ls -a
+
+            - name: Dive
+              uses: yuichielectric/dive-action@0.0.4
+              with:
+                  image: ${{ matrix.targets.tag }}:latest
+                  github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,77 @@
+FROM docker-registry.tools.wmflabs.org/toolforge-php74-sssd-web:latest AS dependencies
+# ===============================================
+#  COMPOSER INSTALL
+# ===============================================
+ENV COPYPATROL_ROOT=/app
+WORKDIR ${COPYPATROL_ROOT}
+
+# Install unzip for safety
+RUN apt update && apt install -y unzip
+
+# Install dependencies
+COPY composer.* ${COPYPATROL_ROOT}
+RUN composer install
+
+FROM docker-registry.tools.wmflabs.org/toolforge-php74-sssd-web:latest AS base
+# ===============================================
+#  BASE IMAGE
+# ===============================================
+ENV COPYPATROL_ROOT=/app
+WORKDIR ${COPYPATROL_ROOT}
+
+# == WORK ==
+
+# Disable file error logging for Lighttpd (enables error logging to stderr)
+RUN sed -i 's!server.errorlog!# server.errorlog!g' /etc/lighttpd/lighttpd.conf
+
+# Enable required Lighttpd modules (rewrite, php)
+RUN lighty-enable-mod fastcgi-php
+RUN lighty-enable-mod rewrite
+
+# add XDebug (if needed)
+RUN apt-get clean && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive && \
+    apt-get install --yes php7.4-xdebug && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Add rewrite rules
+RUN echo 'url.rewrite-if-not-file += ( "(.*)" => "/index.php/$0" )' >> /etc/lighttpd/conf-enabled/90-copypatrol.conf
+
+## Only these two copy statements below actually matter. Everything before this was
+## just to set up a Toolforge-like environment for local development.
+# Copy vendor files
+COPY --from=dependencies ${COPYPATROL_ROOT}/vendor ${COPYPATROL_ROOT}/vendor
+
+# Copy files
+COPY . ${COPYPATROL_ROOT}
+
+# Symlink CopyPatrol public_html to document root
+RUN rm -rf /var/www/html
+RUN ln -s ${COPYPATROL_ROOT}/public_html /var/www/html
+
+# Set start command (enable FastCGI and start lighttpd)
+CMD [ "lighttpd", "-D", "-f", "/etc/lighttpd/lighttpd.conf" ]
+
+FROM base as production
+# ===============================================
+#  PRODUCTION IMAGE
+# ===============================================
+RUN phpdismod xdebug
+
+FROM base as development
+# ===============================================
+#  DEVELOPMENT IMAGE
+# ===============================================
+RUN echo -e "error_reporting=E_ALL\\n\
+\\n\
+[xdebug]\\n\
+xdebug.remote_enable=1\\n\
+xdebug.mode=develop,coverage,debug,profile\\n\
+xdebug.start_with_request=yes\\n\
+xdebug.log=/tmp/xdebug.log\\n\
+xdebug.log_level=0\\n\
+xdebug.remote_host=host.docker.internal\n\
+# XDebug 3\\n\
+xdebug.client_host=host.docker.internal\\n" >> /etc/php/7.4/mods-available/xdebug.ini

--- a/README.md
+++ b/README.md
@@ -4,20 +4,65 @@ This is a web interface for [Plagiabot's Copyright RC feed](https://en.wikipedia
 ## To install locally
 1. Clone the repository and run `composer install`.
 2. Edit the `.env` file that was created by composer.
-   1. Get Oauth tokens by registering a new consumer on Meta
+   1. Get OAuth tokens by registering a new consumer on Meta
       at [Special:OAuthConsumerRegistration](https://meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration).
    2. To use Redis caching, also add `REDIS_HOST` and `REDIS_PORT`;
       without these, a local filesystem cache will be used.
 3. Start a development server with `cd public_html && php -S localhost:8000`
 4. Open up an SSH tunnel to access the databases on Toolforge (substitute your own username).<br>
-   ```
-   $ ssh -L 4711:enwiki.web.db.svc.eqiad.wmflabs:3306 -L 4712:tools.db.svc.eqiad.wmflabs:3306 USERNAME@login.toolforge.org -N
+   ```bash
+   ssh -L 4711:enwiki.web.db.svc.eqiad.wmflabs:3306 -L 4712:tools.db.svc.eqiad.wmflabs:3306 USERNAME@login.toolforge.org -N
    ```
    In this example, `DB_REPLICA_PORT` would be `4711` and `DB_PORT` would be `4712`. Note that the above also only
    allows you to query English Wikipedia. You'll need to change the host accordingly to test other languages, such as
    `eswiki.web.db.svc.eqiad.wmflabs` if you need to test against Spanish Wikipedia.
 
 This application makes of use the [Wikimedia-slimapp](https://github.com/wikimedia/wikimedia-slimapp) library and uses Twig as its templating engine.
+
+### Using Docker
+1. Build the Docker image for CopyPatrol.
+   ```bash
+   docker-compose -f docker-compose.dev.yml build
+   ```
+2. Install Composer packages using the PHP version used by the Docker image. Be sure that your current/present working directory is this repository.
+   ```bash
+   # The `wikimedia/copypatrol-development` image is generated in the first step.
+   docker run --rm -it -v $(pwd):/app wikimedia/copypatrol-development composer install
+   ```
+   On Windows, use the following command instead:
+   ```bash
+   docker run --rm -it -v %CD%:/app wikimedia/copypatrol-development composer install
+   ```
+3. Edit the `.env` file that was created by composer.
+   1. Get OAuth tokens by registering a new consumer on Meta
+      at [Special:OAuthConsumerRegistration](https://meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration).
+   2. Set `DB_HOST` and `DB_REPLICA_HOST` to `host.docker.internal` to use the tunneled ports on the host machine (later step).
+   3. Use the proper username and password for accessing the Replicas and ToolsDB databases.
+4. Open up an SSH tunnel to access the databases on Toolforge (substitute your own username).
+   ```bash
+   ssh -L 4711:enwiki.web.db.svc.wikimedia.cloud:3306 -L 4712:tools.db.svc.wikimedia.cloud:3306 YOU@dev.toolforge.org -N
+   ```
+   In this example, `DB_REPLICA_PORT` would be `4711` and `DB_PORT` would be `4712`. Note that the above also only
+   allows you to query English Wikipedia. You'll need to change the host accordingly to test other languages, such as
+   `eswiki.web.db.svc.eqiad.wmflabs` if you need to test against Spanish Wikipedia.
+5. Run the Docker Compose file. CopyPatrol will be accessible on http://localhost:80
+   ```bash
+   docker-compose -f docker-compose.dev.yml up
+   ```
+
+Redis caching is automatically included within the `docker-compose.dev.yml` file. This is automatically
+used even without further configuration of the `.env` file (which uses a Redis cache by default).
+
+Changes to this folder will automatically be applied to the running Docker container. This includes
+changes to `src` files, `.env`, etc. XDebug is set up to connect to the host machine (the computer
+running the Docker container) on request, see the `Dockerfile` for the specific configuration values.
+
+If you wish to use testing databases instead of the Plagiabot databases live on Toolforge, change `DB_HOST`,
+and all related connection options. You will still need to connect to the Replica DBs for revision
+information, so leave `DB_REPLICA_HOST` untouched and keep tunneling the port for the Replica DB in step 4.
+
+To make a **production-level** build, run `docker build --target production -t wikimedia/copypatrol:latest`.
+XDebug and other related components will be disabled.
 
 ## To add a new translation message:
 1. Add it to en.json
@@ -33,18 +78,18 @@ To add a new language, follow these steps:
 1. Make sure the language is supported by iThenticate. This list is available at http://www.ithenticate.com/products/faqs. Look for the "Which international languages does iThenticate have content for in its database?" section.
 2. Make sure there is community consensus for CopyPatrol. This helps ensure they will **regularly** make use of CopyPatrol. EranBot, which powers the CopyPatrol feed, is expensive in terms of the resources it uses. Any languages that are not regularly being used should be removed.
 3. Make sure the corresponding `-wikipedia` message in `public_html/i18n/en.json` (and qqq.json) exists and is translated in the desired language.
-4. On Toolforge, `become community-tech-tools`, then `become eranbot`. Add the following to the crontab, replcaing `enwiki` and `-lang:en` accordingly:
-```
-*/10 * * * * jsub -N enwiki -mem 500m -l h_rt=4:05:00 -once -quiet -o /data/project/eranbot/outs python /data/project/eranbot/gitPlagiabot/plagiabot/plagiabot.py -lang:en -blacklist:User:EranBot/Copyright/Blacklist -live:on -reportlogger
-```
+4. On Toolforge, `become community-tech-tools`, then `become eranbot`. Add the following to the crontab, replacing `enwiki` and `-lang:en` accordingly:
+   ```
+   */10 * * * * jsub -N enwiki -mem 500m -l h_rt=4:05:00 -once -quiet -o /data/project/eranbot/outs python /data/project/eranbot/gitPlagiabot/plagiabot/plagiabot.py -lang:en -blacklist:User:EranBot/Copyright/Blacklist -live:on -reportlogger
+   ```
 5. Monitor the `.err` file (i.e. enwiki.err) for output. If looks similar to the other .err files, you know it's running properly. Once a copyvio is found and stored in the database, the feed for the new language in CopyPatrol should show up within 7 days (due to caching).
 
 ## To remove a language
 
 1. Remove the entry from `eranbot`'s crontab.
 2. Remove all relevant rows from the database. While logged in as eranbot, run:
-```
-sql local
-MariaDB [(none)]> USE s51306__copyright_p;
-MariaDB [s51306__copyright_p]> DELETE FROM copyright_diffs WHERE lang = 'xx'
-```
+   ```
+   sql local
+   MariaDB [(none)]> USE s51306__copyright_p;
+   MariaDB [s51306__copyright_p]> DELETE FROM copyright_diffs WHERE lang = 'xx'
+   ```

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,58 @@
+version: '3.8'
+
+# =========================================================
+#
+# This file allows anyone to start the CopyPatrol web interface
+# locally. Additional configuration on the `.env` file is still
+# required to bring this up.
+#
+# Ensure the following before bringing this file up (in order):
+#  - CopyPatrol image must be built.
+#    - Use `docker-compose -f docker-compose.dev.yml build` to build the image.
+#  - Composer packages must be installed
+#    - Use `docker run --rm -it -v $(pwd):/app wikimedia/copypatrol composer install` to install packages.
+#  - `.env` contains appropriate credentials
+#    - `OAUTH_CONSUMER_TOKEN` and `OAUTH_SECRET_TOKEN` must be supplied
+#    - SQL usernames and passwords must be supplied
+#    - `DB_HOST` and `DB_REPLICA_HOST` must be `host.docker.internal`
+#  - Replica SQL DB must be accessible through port 4711 on the host (see README)
+#  - Tool SQL DB must be accessible through port 4712 on the host (see README)
+#
+# =========================================================
+
+volumes:
+    redis:
+
+services:
+    copypatrol:
+        build:
+            context: .
+            dockerfile: Dockerfile
+            target: development
+        image: wikimedia/copypatrol-development
+        depends_on:
+            -   copypatrol-redis
+        links:
+            - "copypatrol-redis:tools-redis"
+        extra_hosts:
+            - host.docker.internal:host-gateway
+        ports:
+            - "80:80"
+        volumes:
+            # This will bind the files in the development directory to the app.
+            -   type: bind
+                source: "."
+                target: "/app"
+                read_only: true
+            # Cache directory should not be read-only
+            -   type: bind
+                source: "./cache"
+                target: "/app/cache"
+        restart: always
+        stop_grace_period: 1m
+    copypatrol-redis:
+        image: redis:alpine
+        volumes:
+            -   redis:/data
+        restart: always
+        stop_grace_period: 1m


### PR DESCRIPTION
This commit adds a Dockerfile for building a reproducible image of CopyPatrol based on Toolforge PHP 7.4 images. The Dockerfile mostly emulates the Toolforge environment, with slight modifications in development mode to make development easier (such as enabling XDebug in development mode).

The `docker-compose.dev.yml` file ensures that CopyPatrol is started with additional services, such as Redis, and mounts, such as the main program mount on the public user directory. It also ensures that port 9000/9003 are made accessible within the container to allow remote XDebug step debugging.

Note that the Docker Compose file binds to port 80 for the webserver. As the Twig templates are written now, ports are not properly handled when linking to server resources.

This adds the following checks:
* Build Docker image – performed on both `production` and `development` targets.
* Analyze Docker images – performs an efficiency check on the built Docker images using [Dive](https://github.com/wagoodman/dive).