### PR TITLE
Correct parameter name in docs

### DIFF
--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -29,14 +29,14 @@ class ApiController extends AppController {
 	 *     schema=@OA\Schema(type="string", enum={"all", "open", "reviewed"})
 	 * )
 	 * @OA\Parameter(
-	 *     name="filter_user",
+	 *     name="filterUser",
 	 *     in="query",
 	 *     description="Filter the results by reviewer",
 	 *     required=false,
 	 *     schema=@OA\Schema(type="string")
 	 * )
 	 * @OA\Parameter(
-	 *     name="filter_page",
+	 *     name="filterPage",
 	 *     in="query",
 	 *     description="Filter by page title. This is a **case-sensitive** substring match.",
 	 *     required=false,


### PR DESCRIPTION
Currently, the parameter names for the feed filtering API do not correspond to the parameters accepted by the API giving the appearance that the API is broken. For example, [the docs](http://copypatrol.wmcloud.org/api) give me the following command to filter for a specific page:
```sh
curl -X 'GET' \
  'https://copypatrol.wmcloud.org/api/feed/en?filter=all&filter_page=List%20of%20foreign%20recipients%20of%20the%20L%C3%A9gion%20d%27Honneur%20by%20country' \
  -H 'accept: application/json'
```
However, when the command is run, the default list of pages is returned and no filtering occurs. The correct command would have been
```sh
curl -X 'GET' \
  'https://copypatrol.wmcloud.org/api/feed/en?filter=all&filterPage=List%20of%20foreign%20recipients%20of%20the%20L%C3%A9gion%20d%27Honneur%20by%20country' \
  -H 'accept: application/json'
```
which filters the pages and provides only the page that matches the name provided in the query.

This patch fixes the parameter names in the OpenAPI docs to correspond to the actual API parameters.

