### PR TITLE
Add getPlagiarismRecordsCount function, and show open case count

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -106,6 +106,21 @@ class AppController extends AbstractController {
 		// Add the logged in user's rights to the response, so we can conditionally show links for sysops.
 		$ret['user_rights'] = $currentUser ? $wikiRepo->getUserRights( $currentUser->username ) : [];
 
+		$open_records_count = $copyPatrolRepo->getPlagiarismRecordsCount(
+			array_merge(
+				$options,
+				[
+					'filter' => CopyPatrolRepository::FILTER_OPEN
+				]
+			)
+		);
+		// If there are 200 (or more) open records, we just show "200+".
+		if ( $open_records_count >= 200 ) {
+			$ret['open_records_count'] = "200+";
+		} else {
+			$ret['open_records_count'] = $open_records_count;
+		}
+
 		return $this->render( 'feed.html.twig', $ret );
 	}
 

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -52,7 +52,7 @@
 									<label>
 										<input type="radio" name="filter" value="{{ type }}"
 											{% if filter == type %} checked="checked"{% endif %}
-										/> {{ msg('form-'~type) }}
+										/> {{ msg('form-'~type) }} {% if type == "open" %} (<span id="open_records_count" data-count="{{ open_records_count }}">{{ open_records_count }}</span>) {% endif %}
 									</label>
 								</span>
 							{% endfor %}


### PR DESCRIPTION
Adds a function named `getPlagiarismRecordsCount`, which accepts the same filtering options as `getPlagiarismRecords`, has a higher limit (200) and caches the count result for 15 minutes.

This is called in `AppController` as such:
```php
$open_records_count = $copyPatrolRepo->getPlagiarismRecordsCount(
	array_merge(
		$options,
		[
			'filter' => CopyPatrolRepository::FILTER_OPEN
		]
	)
);
// If there are 200 (or more) open records, we just show "200+".
if ( $open_records_count >= 200 ) {
	$ret['open_records_count'] = "200+";
} else {
	$ret['open_records_count'] = $open_records_count;
}
```

Requesting more than 200 records to count appears to be detrimental to performance, so currently if the result is 200 (or more), the string `200+` is displayed.
![image](https://github.com/user-attachments/assets/fbe67c44-67b9-422c-b8b3-6ee5e0c09d0a)

The count is wrapped in `<span id="open_records_count" data-count="{{ open_records_count }}">{{ open_records_count }}</span>` to make it marginally easier to parse the page with a bot/etc (as it was mentioned that an on-wiki rough count would also be beneficial)

Bug: T375528